### PR TITLE
fix #20 strip hashmark from filename so it gets assigned to Az playlists

### DIFF
--- a/arcsi/api/utils.py
+++ b/arcsi/api/utils.py
@@ -34,7 +34,7 @@ def slug(namestring):
 
 def normalise(namestring):
     stripped = unicodedata.normalize("NFD", namestring).encode("ascii", "ignore")
-    norms = stripped.decode("utf-8").lower().replace(" ", "_")
+    norms = stripped.decode("utf-8").lower().replace(" ", "_").replace("#", "_")
     return norms
 
 


### PR DESCRIPTION
Aims to fix issue #20 

We didn't encode hashmark in our end for filename but Azura does. So when trying to assign audio file to playlist it couldn't find the audio file. It only occured on hashmark so this pull request only fixes that. We can aim to cover other characters too but I didn't have capacity to test them all. 

Tested on dev, fixes the issue
