### PR TITLE
Basic logging setup

### DIFF
--- a/arcsi/__init__.py
+++ b/arcsi/__init__.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 from flask import Flask
@@ -13,6 +14,11 @@ migrate = Migrate()
 def create_app(config_file):
     # create and configure the app
     app = Flask(__name__, instance_relative_config=True)
+    
+    # set logger and log-handler and log-level so that Gunicorn and Flask share
+    guni_logger = logging.getLogger('gunicorn.error')
+    app.logger.handlers = guni_logger.handlers
+    app.logger.setLevel(guni_logger.level)
 
     # ensure the instance folder exists
     try:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 python3 -m flask db upgrade
-gunicorn --worker-tmp-dir /dev/shm -w 4 --worker-class=gthread --threads 8 -b 0.0.0.0:5666 --log-file /app/aguni.log --log-level debug "arcsi:create_app('../config.py')"
+gunicorn --worker-tmp-dir /dev/shm -w 4 --worker-class=gthread --threads 8 -b 0.0.0.0:5666 --log-file /app/aguni.log --log-level info "arcsi:create_app('../config.py')"


### PR DESCRIPTION
Use app logger but with gunicorn's handlers & log-level so we have unified control over what is logged by Flask & gunicorn both.  

I changed the default log-level in `entrypoint` to info so that log messages sent with debug log-level are not logged by default for production. For dev and local, we can start them w/ debug log-level for work & development purposes. 

