### PR TITLE
More conservative numbers for gunicorn

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 python3 -m flask db upgrade
-gunicorn --worker-tmp-dir /dev/shm -w 2 --worker-class=gthread --threads 4 -b 0.0.0.0:5666 --log-file /app/aguni.log --log-level info "arcsi:create_app('../config.py')"
+gunicorn --worker-tmp-dir /dev/shm -w 1 --worker-class=gthread --threads 2 -b 0.0.0.0:5666 --log-file /app/aguni.log --log-level info "arcsi:create_app('../config.py')"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 python3 -m flask db upgrade
-gunicorn --worker-tmp-dir /dev/shm -w 1 --worker-class=gthread --threads 2 -b 0.0.0.0:5666 --log-file /app/aguni.log --log-level info "arcsi:create_app('../config.py')"
+gunicorn --worker-tmp-dir /dev/shm -w 2 --worker-class=gthread --threads 2 -b 0.0.0.0:5666 --log-file /app/aguni.log --log-level info "arcsi:create_app('../config.py')"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 python3 -m flask db upgrade
-gunicorn --worker-tmp-dir /dev/shm -w 4 --worker-class=gthread --threads 8 -b 0.0.0.0:5666 --log-file /app/aguni.log --log-level info "arcsi:create_app('../config.py')"
+gunicorn --worker-tmp-dir /dev/shm -w 2 --worker-class=gthread --threads 4 -b 0.0.0.0:5666 --log-file /app/aguni.log --log-level info "arcsi:create_app('../config.py')"


### PR DESCRIPTION
We have smallish available memory so the upkeep for these workers normally used is bit too high. 

Lowered it and checked that memory is indeed not used by the extra workers and threads 