### PR TITLE
#33 Setup new architecture w/ CDN edge

### DIFF
--- a/arcsi/handler/upload.py
+++ b/arcsi/handler/upload.py
@@ -71,18 +71,12 @@ class DoArchive(object):
             aws_secret_access_key=self.config["secret_key"],
         )
 
-        self.presigned = cli.generate_presigned_url(
+        self.dl_file = cli.generate_presigned_url(
             "get_object",
+            ExpiresIn=0,
             Params={"Bucket": self.config["space"], "Key": "{}".format(path),},
         )
-        return self.presigned
-
-    # TODO cant do this w/o db entry but then its perhaps easier to set expiry time in db
-    def valid_presigned(self, url):
-        req = requests.post(self.presigned)
-        if req.ok:
-            return True
-        return False
+        return self.dl_file
 
     # TODO STUB lets see what the final architecture would look like
     def batch_upload(self):

--- a/arcsi/handler/upload.py
+++ b/arcsi/handler/upload.py
@@ -71,11 +71,12 @@ class DoArchive(object):
             aws_secret_access_key=self.config["secret_key"],
         )
 
+        # there seems to be no cleaner way to get the public URI
         self.dl_file = cli.generate_presigned_url(
             "get_object",
             ExpiresIn=0,
             Params={"Bucket": self.config["space"], "Key": "{}".format(path),},
-        )
+        ).split("?")[0]
         return self.dl_file
 
     # TODO STUB lets see what the final architecture would look like

--- a/arcsi/handler/upload.py
+++ b/arcsi/handler/upload.py
@@ -54,7 +54,9 @@ class DoArchive(object):
         )
         try:
             res = cli.upload_file(
-                self.file, self.config["space"], "{}/{}".format(number, self.filename)
+                self.file, self.config["space"], 
+                "{}/{}".format(number, self.filename), 
+                ExtraArgs={"ACL":"public-read"},
             )
         except ClientError:
             return False

--- a/arcsi/handler/upload.py
+++ b/arcsi/handler/upload.py
@@ -25,15 +25,16 @@ from mutagen.mp3 import MP3
 class DoArchive(object):
     def __init__(self):
         self.config = {
-            "region": app.config["ARCHIVE_REGION"],  # digitalocean region
-            "host": app.config["ARCHIVE_HOST_BASE_URL"],  # digitalocean droplet IP
+            "region": app.config["ARCHIVE_REGION"],  # region
+            "host": app.config["ARCHIVE_HOST_BASE_URL"],  # origin
+            "endpoint": app.config["ARCHIVE_ENDPOINT"],  # public
             "api_key": app.config[
                 "ARCHIVE_API_KEY"
-            ],  # digitalocean access key see API_KEYS
+            ],
             "secret_key": app.config[
                 "ARCHIVE_SECRET_KEY"
-            ],  # digitalocean secret key see API_KEYS
-            "space": "",  # digitalocean upload space (eg. bucket)
+            ],
+            "space": "",  # s3 bucket name
         }
 
     # Should we have one session for class instance or one each for each method called?

--- a/arcsi/handler/upload.py
+++ b/arcsi/handler/upload.py
@@ -63,24 +63,10 @@ class DoArchive(object):
         return "{}/{}".format(number, self.filename)
 
     def download(self, space, path):
+        # TODO if space and dl file URL always change they don't need to be class attributes
         self.config["space"] = space
-
-        sess = boto3.session.Session()
-        cli = sess.client(
-            "s3",
-            region_name=self.config["region"],
-            endpoint_url=self.config["host"],
-            aws_access_key_id=self.config["api_key"],
-            aws_secret_access_key=self.config["secret_key"],
-        )
-
-        # there seems to be no cleaner way to get the public URI
-        self.dl_file = cli.generate_presigned_url(
-            "get_object",
-            ExpiresIn=0,
-            Params={"Bucket": self.config["space"], "Key": "{}".format(path),},
-        ).split("?")[0]
-        return self.dl_file
+        self.dl_file_url = "{}/{}/{}".format(self.config["endpoint"], self.config["space"], path)
+        return self.dl_file_url
 
     # TODO STUB lets see what the final architecture would look like
     def batch_upload(self):

--- a/config.template.py
+++ b/config.template.py
@@ -22,6 +22,7 @@ ARCHIVE_REGION = "jams4"  # used by boto3; depending on storage service might di
 ARCHIVE_HOST_BASE_URL = (
     "https://ip-or-url-of-provid.er"  # used by boto3; an IP or public URL
 )
+ARCHIVE_ENDPOINT = "https://cdn.ed.ge"  # public URL or CDN edge
 ARCHIVE_API_KEY = (
     "some-api-key-from-provider"  # used by boto3; access key from provider's interface
 )


### PR DESCRIPTION
Added new possibility to add CDN edge endpoint URL to the config which is then used when downloading files (saving costs and bandwidth). 
Main points:
- For this to work we now set public read ACL on the uploaded files as well as constructing the download path w/ the CDN endpoint URL
- We introduced ARCHIVE_ENDPOINT (perhaps not the best naming idea) as public URL media handler should use
- refactored storage download handler so it uses CDN (should revisit to add some fallback & smarts to this later)

This means once the already stored assets are set to public this can be merged and it can start receiving live requests I think 