### PR TITLE
Removing spec. chars from all media filenames

### DIFF
--- a/arcsi/api/utils.py
+++ b/arcsi/api/utils.py
@@ -1,5 +1,4 @@
 import os
-import unicodedata
 
 from arcsi.handler.upload import AzuraArchive, DoArchive
 from arcsi.model import db
@@ -33,8 +32,8 @@ def slug(namestring):
 
 
 def normalise(namestring):
-    stripped = unicodedata.normalize("NFD", namestring).encode("ascii", "ignore")
-    norms = stripped.decode("utf-8").lower().replace(" ", "_").replace("#", "_")
+    slugged = slugify(namestring)
+    norms = slugged.replace("-", "_")
     return norms
 
 


### PR DESCRIPTION
Previously we had nimble and unstable way to sanitise some incoming or constructed names for audio or image files. I switched to the slugify since we already use it for other purposes. I only changed the underlying logic of the util we use in the API layer so nothing has had to be changed anywhere else. 

I did couple of quick tests in my REPL but not w/ actual test server. Feel free to give it a spin! 
multiple spec. chars 
```
>>> specstring="á/@"
>>> sluggish=slugify(specstring)
>>> strippish=unicodedata.normalize("NFD",specstring).encode("ascii", "ignore").decode("utf-8").lower()
>>> print("{} vs {}".format(sluggish, strippish))
a vs a/@
```
multiple spaces and uppercase
```
>>> bigvalupper="BABA MAMA PAPA ANYA APA"
>>> bigsl=slugify(bigvalupper).replace("-","_")
>>> print(bigsl)
baba_mama_papa_anya_apa
```

I hoped it was nicer and simpler and give us more control to use simple built-in `unicodedata` for sanitisation and I might revisit this -- but since we already need to collect this third party lib for other tasks it won't save us much to not use it in other parts. What do you think @gammaw ?