### PR TITLE
Have a single worker

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 python3 -m flask db upgrade
-gunicorn --worker-tmp-dir /dev/shm -w 2 --worker-class=gthread --threads 2 -b 0.0.0.0:5666 --log-file /app/aguni.log --log-level debug "arcsi:create_app('../config.py')"
+gunicorn --worker-tmp-dir /dev/shm -w 1 --worker-class=gthread --threads 4 -b 0.0.0.0:5666 --log-file /app/aguni.log --log-level debug "arcsi:create_app('../config.py')"


### PR DESCRIPTION
#57
Rationale: multiple workers are more expensive than multiple threads. Workers are recommended in case of CPU heavy load (which we don't have) and also if multiple cores are available (which we don't have either).