### PR TITLE
Fix #69 and first step to decouple media processing actions from episode handling

### DIFF
--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -191,7 +191,7 @@ def add_show():
                     new_show.cover_image_url = archive(
                         archive_base=new_show.archive_lahmastore_base_url,
                         archive_idx=0,
-                        image_file_name=cover_image_name,
+                        archive_file_name=cover_image_name,
                     )
 
         db.session.commit()

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -9,13 +9,14 @@ from flask import current_app as app
 from marshmallow import fields, post_load, Schema, ValidationError
 from werkzeug import secure_filename
 
-from .utils import media_path, slug, process_image
+from .utils import archive, process, slug
 from arcsi.api import arcsi
 from arcsi.handler.upload import DoArchive
 from arcsi.model import db
 from arcsi.model.item import Item
 from arcsi.model.show import Show
 from arcsi.model.user import User
+
 
 class ShowDetailsSchema(Schema):
     id = fields.Int()
@@ -37,12 +38,24 @@ class ShowDetailsSchema(Schema):
     items = fields.List(
         fields.Nested(
             "ItemDetailsSchema",
-            only=("id", "archived", "description", "name", "number", "play_date", "image_url"),
+            only=(
+                "id",
+                "archived",
+                "description",
+                "name",
+                "number",
+                "play_date",
+                "image_url",
+            ),
         ),
         dump_only=True,
     )
     users = fields.List(
-        fields.Nested("UserDetailsSchema", only=("id", "name", "email"),), required=True
+        fields.Nested(
+            "UserDetailsSchema",
+            only=("id", "name", "email"),
+        ),
+        required=True,
     )
 
     @post_load
@@ -55,6 +68,7 @@ show_details_partial_schema = ShowDetailsSchema(partial=True)
 many_show_details_schema = ShowDetailsSchema(many=True)
 
 headers = {"Content-Type": "application/json"}
+
 
 @arcsi.route("/show", methods=["GET"])
 @arcsi.route("/show/all", methods=["GET"])
@@ -96,9 +110,17 @@ def view_archive(slug):
     show = show_query.first_or_404()
     if show:
         show_json = show_details_schema.dump(show)
-        show_items = [show_item for show_item in show_json["items"] if datetime.strptime(show_item.get("play_date"), "%Y-%m-%d")+timedelta(days=1) < datetime.today()]
+        show_items = [
+            show_item
+            for show_item in show_json["items"]
+            if datetime.strptime(show_item.get("play_date"), "%Y-%m-%d")
+            + timedelta(days=1)
+            < datetime.today()
+        ]
         for show_item in show_items:
-            show_item["image_url"] = do.download(show.archive_lahmastore_base_url, show_item["image_url"])
+            show_item["image_url"] = do.download(
+                show.archive_lahmastore_base_url, show_item["image_url"]
+            )
         return json.dumps(show_items)
     else:
         return make_response("Show not found", 404, headers)
@@ -159,11 +181,26 @@ def add_show():
 
         if request.files:
             if request.files["image_file"]:
-                process_image(request.files["image_file"], new_show)
+                cover_image_name = process(
+                    archive_base=new_show.archive_lahmastore_base_url,
+                    archive_idx=0,
+                    archive_file=request.files["image_file"],
+                    archive_name=(new_show.name, "cover"),
+                )
+                if cover_image_name:
+                    new_show.cover_image_url = archive(
+                        archive_base=new_show.archive_lahmastore_base_url,
+                        archive_idx=0,
+                        image_file_name=cover_image_name,
+                    )
 
         db.session.commit()
 
-        return make_response(jsonify(show_details_schema.dump(new_show)), 200, headers,)
+        return make_response(
+            jsonify(show_details_schema.dump(new_show)),
+            200,
+            headers,
+        )
 
 
 @arcsi.route("/show/<id>", methods=["DELETE"])
@@ -228,10 +265,20 @@ def edit_show(id):
 
         if request.files:
             if request.files["image_file"]:
-                process_image(request.files["image_file"], show)
+                cover_image_name = process(
+                    archive_base=show.archive_lahmastore_base_url,
+                    archive_idx=0,
+                    archive_file=request.files["image_file"],
+                    archive_name=(show.name, "cover"),
+                )
+                if cover_image_name:
+                    show.cover_image_url = archive(
+                        archive_base=show.archive_lahmastore_base_url,
+                        archive_idx=0,
+                        archive_file_name=cover_image_name,
+                    )
 
         db.session.commit()
         return make_response(
             jsonify(show_details_partial_schema.dump(show)), 200, headers
         )
-

--- a/arcsi/api/utils.py
+++ b/arcsi/api/utils.py
@@ -106,12 +106,11 @@ def process(archive_base, archive_idx, archive_file, archive_name):
     
 
 def archive(archive_base, archive_file_name, archive_idx):
-        do = DoArchive()
+    do = DoArchive()
 
-        archive_file_path = media_path(
-            archive_base, str(archive_idx), archive_file_name
-        )
-        archive_url = do.upload(archive_file_path, archive_base, archive_idx)
-        return archive_url
-    else:
-        return None
+    archive_file_path = media_path(
+        archive_base, str(archive_idx), archive_file_name
+    )
+    archive_url = do.upload(archive_file_path, archive_base, archive_idx)
+    
+    return archive_url

--- a/arcsi/api/utils.py
+++ b/arcsi/api/utils.py
@@ -34,11 +34,6 @@ def normalise(namestring):
     norms = slugged.replace(DELIMITER, CONNECTER)
     return norms
 
-
-def show_or_not(item_obj):
-    return True if isinstance(item_obj, Show) else False
-
-
 def slug(namestring):
     slugs = slugify(namestring)
     return slugs


### PR DESCRIPTION
**Why?**
It started off as quick-fix for issue #69 but since we had issues with this weak setup we used anyway I started to separate media processing, media archiving, media broadcasting. It is not full rewrite but just step in that direction while the app still works with the same UI and API payload.

**What did I do?**
Introduced `archive()`, `process()` generic functions instead of `process_media()` interface. 

Rewrote parts of add show, edit show, add item, edit item where we deal w/ media handling to use these functions. I made small changes in `form_filename()` (*this is the relevant part to issue #69 fixing that!*) and attempted to improve `broadcast_audio()` too. 

I also formatted the files I touched w/ black. We lost that somewhere but I think it is really-really good and well opinionated so I hope we keep using it.

**Does this do what it is intended to do and nothing more?**
I did tests to verify that this refactor doesn't cause any regressions. 

Add new show 
 - w/ image
   - expected: New show created
   - result: ✅ 
 - w/o image 
   - expected: New show created
   - result: ✅ 

Edit show 
 - w/ image
   - expected: Show cover updated
   - result: ✅ 
 - w/o image 
   - expected: No changes
   - result: ✅ 

Add new episode
 - archive
   - w/o image or audio
     - expected: New ep. created
     - result: ✅ 
   - w/ image only
     - expected: New ep. created
     - result: ✅ 
   - w/ audio only
     - expected: New ep. created
     - result: ✅ 
   - w/ image & audio
     - expected: New ep. created
     - result: ✅ 
 - broadcast
   - w/o image or audio
     - expected: Returns error
     - result: ✅ 
   - w/ image only
     - expected: Returns error
     - result: ✅ 
   - w/ audio only
     - expected: Returns error
     - result: ✅ 
   - w/ image & audio
     - expected: New ep. broadcasted
     - result: ✅ 
    
Edit episode
 - archive
   - w/o image or audio
     - expected: New ep. created
     - result: ✅ 
   - w/ image only
     - expected: New ep. created
     - result: ✅ 
   - w/ audio only
     - expected: New ep. created
     - result: ✅ 
   - w/ image & audio
     - expected: New ep. created
     - result: ✅ 
 - broadcast
   - w/o image or audio
     - expected: Returns error
     - result: ✅ 
   - w/ image only
     - expected: Returns error
     - result: ✅ 
   - w/ audio only
     - expected: Returns error
     - result: ✅ 
   - w/ image & audio
     - expected: New ep. broadcasted
     - result: ✅ 

Sorry for the bad branch name and introducing massive changes. This is just the first step. My code is so bad, I'll need to rewrite it quite heavily until it is effective and simple. 


Please let me know if you find something. I didn't have much time to really flesh this out but I would like to have this available for handling upcoming new shows.

