### PR TITLE
update to help future Windows developers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+text=lf
+ *.css linguist-vendored eol=lf
+ *.js linguist-vendored eol=lf
+ *.py eol=lf
+ *.env eol=lf
+ *.template eol=lf
+ *.yml eol=lf
+ *.sh eol=lf
+ *.conf eol=lf
+ CHANGELOG.md export-ignore 

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ docs/_build/
 *override.yml
 pg-data
 nginx/arcsi.conf
+*.sql


### PR DESCRIPTION
Related: #86
the .gitattributes file helps to evade Windows' auto CRLF line endings nightmare