### PR TITLE
Dynamically add db connection values from .env file

### DIFF
--- a/config.template.py
+++ b/config.template.py
@@ -4,7 +4,12 @@ import os
 SECRET_KEY = "yoursecretkeynotinversioncontrol"  # Never share! This is used to sign session. Note: https://github.com/pallets/itsdangerous/issues/41#issuecomment-69416785
 
 # DB
-SQLALCHEMY_DATABASE_URI = "postgresql://postgres:postgres@db/arcsi"  # used by Sqlalchemy ORM; can be Mysql, Postgresql, sqlite, mongo etc.
+# Set in db.env
+SQLALCHEMY_DATABASE_URI = "postgresql://{}:{}@db/{}".format(
+    os.getenv("POSTGRES_USER"),
+    os.getenv("POSTGRES_PASSWORD"),
+    os.getenv("POSTGRES_DB")
+    )  # used by Sqlalchemy ORM; can be Mysql, Postgresql, sqlite, mongo etc.
 SQLALCHEMY_TRACK_MODIFICATIONS = (
     False  # https://github.com/pallets/flask-sqlalchemy/issues/365
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - db
     env_file: 
         - app.env
+        - db.env
     # there is no `depend_on: condition:` in compose service v3
     entrypoint: sh -c 'sleep 60; /app/entrypoint.sh'
 


### PR DESCRIPTION
This was hardcoded until now and unnecessarily so. 

I've added the `db.env` file as `env_file` to arcsi's docker compose Yml so we can use the values of it via `os.getenv()`

Since the same env values are used for both database setup and connection we should be sure that they will match & work. If there are any issues however we will just fail during web service start so there is no need for extra defensive code, I think. 

Please check it out, I tested locally but you may do it too -- if it is right I hope we can merge it quick. Thanks!