### PR TITLE
Fix #8 -- Fix premature role creation during app startup

### DIFF
--- a/arcsi/__init__.py
+++ b/arcsi/__init__.py
@@ -4,6 +4,7 @@ import os
 from flask import Flask
 from flask_security import Security, SQLAlchemySessionUserDatastore
 from flask_migrate import Migrate
+from sqlalchemy.exc import ProgrammingError
 
 from arcsi.model import db, item, role, show, user
 from arcsi.view.forms.register import ButtRegisterForm
@@ -38,15 +39,24 @@ def create_app(config_file):
         db.init_app(app)
         migrate.init_app(app, db)
 
-        # create arcsi roles: 
-        # `admin` => access to whole service, 
-        # `host` => acces to their show, 
-        # `guest` => acces to their episode
-        user_store.find_or_create_role(name='admin', description='Radio staff')
-        user_store.find_or_create_role(name='host', description='Show host')
-        user_store.find_or_create_role(name='guest', description='Episode guest')
-        db.session.commit()
-
+        '''
+        The application factory runs when `flask db upgrade` is called
+        in entrypoint. At this stage we don't have `roles` relations available.
+        So we let `user_store` fail silently on first try. 
+        This allows the `db upgrade` to set up all relations, which enables
+        us to create these roles once gunicorn starts.
+        '''
+        try:
+            # create arcsi roles: 
+            # `admin` => access to whole service, 
+            # `host` => acces to their show, 
+            # `guest` => acces to their episode
+            user_store.find_or_create_role(name='admin', description='Radio staff')
+            user_store.find_or_create_role(name='host', description='Show host')
+            user_store.find_or_create_role(name='guest', description='Episode guest')
+            db.session.commit()
+        except ProgrammingError as err:
+            pass
 
     from arcsi import api
     from arcsi import view


### PR DESCRIPTION
**Why?**
We have been facing an issue (#8 ) when starting new instances where the app would go and try create roles before the `roles` relation was present in the db. You had to block comment those lines out in `__init__.py` first then undo and run it for the 2nd time. I investigated the root & propose fix here.

**What was the cause?**

```sh
web_1      |   File "/usr/local/lib/python3.8/site-packages/flask/cli.py", line 966, in main
web_1      |     cli.main(prog_name="python -m flask" if as_module else None)
web_1      |   File "/usr/local/lib/python3.8/site-packages/flask/cli.py", line 586, in main
web_1      |     return super(FlaskGroup, self).main(*args, **kwargs)
web_1      |   File "/usr/local/lib/python3.8/site-packages/click/core.py", line 717, in main
web_1      |     rv = self.invoke(ctx)
web_1      |   File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1137, in invoke
web_1      |     return _process_result(sub_ctx.command.invoke(sub_ctx))
web_1      |   File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1137, in invoke
web_1      |     return _process_result(sub_ctx.command.invoke(sub_ctx))
web_1      |   File "/usr/local/lib/python3.8/site-packages/click/core.py", line 956, in invoke
web_1      |     return ctx.invoke(self.callback, **ctx.params)
web_1      |   File "/usr/local/lib/python3.8/site-packages/click/core.py", line 555, in invoke
web_1      |     return callback(*args, **kwargs)
web_1      |   File "/usr/local/lib/python3.8/site-packages/click/decorators.py", line 17, in new_func
web_1      |     return f(get_current_context(), *args, **kwargs)
web_1      |   File "/usr/local/lib/python3.8/site-packages/flask/cli.py", line 425, in decorator
web_1      |     with __ctx.ensure_object(ScriptInfo).load_app().app_context():
web_1      |   File "/usr/local/lib/python3.8/site-packages/flask/cli.py", line 388, in load_app
web_1      |     app = locate_app(self, import_name, name)
web_1      |   File "/usr/local/lib/python3.8/site-packages/flask/cli.py", line 240, in locate_app
web_1      |     __import__(module_name)
web_1      |   File "/app/run.py", line 3, in <module>
web_1      |     app = create_app("../config.py")
```

The issue was due to our `entrypoint.sh` invoking `python3 -m flask db upgrade`. Calling `flask` triggers the app's `run.py` which calls the app factory method `create_app()` where we would create roles. But that's before we have the tables! Only after `run.py` happening would the `db upgrade` CLI command begin which is responsible for creating the needed tables. However once the db upgrade runs we have the tables ready and then Gunicorn calling the app factory would correctly be able to set up the needed roles. This was unintended and thought out poorly. 

**What's the fix?**
When the user store related lines are called we make sure to wrap them in a try-catch w/ a `sqlalchemy.exc.ProgrammingError` which we just let silently fail. This was the first time app factory runs it will skip these and will succeed during the second run. 

I couldn't think of any other circumstance when we would face this exception on startup which is why fails silently. If that should be handled more thoroughly I'm open to amend it.

I tested this locally w/ some debug print messages sprinkled across `create_app()` and confirmed that it works as expected. 
On 1st call, `db upgrade` exception is caught: 
> web_1      | Issue creating roles: (psycopg2.errors.UndefinedTable) relation "roles" does not exist
> web_1      | Finished extension setup w/ app context

On 2nd call, Gunicorn running migration context works and roles are committed to the session: 
> web_1      | INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
> web_1      | INFO  [alembic.runtime.migration] Will assume transactional DDL.
> web_1      | INFO  [alembic.runtime.migration] Running upgrade  -> ff6b0772ed42, empty message
> (...)
> web_1      | arcsi roles committed
> web_1      | Finished extension setup w/ app context

App is ready & available: 
> nginx_1    | 172.18.0.1 - - [18/May/2021:23:36:17 +0000] "GET / HTTP/1.1" 200 2482 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:87.0) Gecko/20100101 Firefox/87.0" "-"