### PR TITLE
Introducing extension validation 

### DIFF
--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -178,7 +178,7 @@ def add_item():
                         archive_name=(new_item.shows[0].name, new_item.name),
                     )
 
-            if not (image_file_name or new_item.play_file_name):
+            if not (image_file_name and new_item.play_file_name):
                 no_error = False
         # archive files if asked
         if new_item.archive_lahmastore:
@@ -342,7 +342,7 @@ def edit_item(id):
                         archive_file=play_file,
                         archive_name=(item.shows[0].name, item.name),
                     )
-            if not (image_file_name or item.play_file_name):
+            if not (image_file_name and item.play_file_name):
                 no_error = False
 
         # archive files if asked

--- a/config.template.py
+++ b/config.template.py
@@ -6,10 +6,8 @@ SECRET_KEY = "yoursecretkeynotinversioncontrol"  # Never share! This is used to 
 # DB
 # Set in db.env
 SQLALCHEMY_DATABASE_URI = "postgresql://{}:{}@db/{}".format(
-    os.getenv("POSTGRES_USER"),
-    os.getenv("POSTGRES_PASSWORD"),
-    os.getenv("POSTGRES_DB")
-    )  # used by Sqlalchemy ORM; can be Mysql, Postgresql, sqlite, mongo etc.
+    os.getenv("POSTGRES_USER"), os.getenv("POSTGRES_PASSWORD"), os.getenv("POSTGRES_DB")
+)  # used by Sqlalchemy ORM; can be Mysql, Postgresql, sqlite, mongo etc.
 SQLALCHEMY_TRACK_MODIFICATIONS = (
     False  # https://github.com/pallets/flask-sqlalchemy/issues/365
 )
@@ -23,6 +21,7 @@ SECURITY_PASSWORD_SALT = "some_salt"
 
 # ARCSI CONF
 UPLOAD_FOLDER = "/abs/path/on/your/machine"  # this is where arcsi stores uploadable files temporarily
+ALLOWED_EXTENSIONS = ["mp3", "gif", "jpg", "jpeg", "png"]
 ARCHIVE_REGION = "jams4"  # used by boto3; depending on storage service might differ. AWS example: `eu-west-1`, DO example: `nyc1`
 ARCHIVE_HOST_BASE_URL = (
     "https://ip-or-url-of-provid.er"  # used by boto3; an IP or public URL


### PR DESCRIPTION
Currently we only check that file in request sent to API is present (ie. not empty)

I introduced a utility method that takes an allowed extension list (I put this in config for ease of working with it in the future, note: **after merge config update is needed on live instances**) and compares the filename extension to it

To solve the issue presented in #13 I created list for valid audio then list for valid image extensions and added checks to show and episode API's separately.

I think ideally this validation could/should happen right in the client but it's not too expensive and bad to have something defensive like this deep down in the API (we can always remove it later too). So I added it to our backend for now.

Another note. I could have updated the "error message" to reflect that we might now fail b/c of this but I'd rather focus on adding proper extension handling. 

Please do run 1 test or 2. Looked okay on my end but who knows.