### PR TITLE
Fix/api endpoints

### DIFF
--- a/arcsi/api/__init__.py
+++ b/arcsi/api/__init__.py
@@ -9,3 +9,29 @@ from .user import *
 
 # TODO add routing here eg
 # arcsi.route("/archive", methods=["GET"])(<method_name>)
+
+
+@arcsi.route("show/<string:show_slug>/archive", methods=["GET"])
+def view_show_archive(show_slug):
+    show_query = Show.query.filter_by(archive_lahmastore_base_url=show_slug)
+    show = show_query.first_or_404()
+    if show:
+        # filter_date = datetime.today() - timedelta(days=1)
+        # airing_date = Item.play_date
+        # filter_hour = datetime.now() - timedelta(days=1)
+        # airing_hour = show.start
+        show_items = show.items.filter(Item.play_date + show.start < datetime.now() - timedelta(days=1)).all()
+        return jsonify(many_item_details_schema.dumps(show_items))
+    else:
+        return make_response("Show not found", 404, headers)
+
+
+@arcsi.route("show/<string:show_slug>/episode/<string:episode_slug>", methods=["GET"])
+def view_episode_archive(show_slug, episode_slug):
+    episode_slug += ".mp3"
+    item_query = Show.query.filter_by(archive_lahmastore_base_url=show_slug).join(Item, Show.items).first().items.filter_by(play_file_name=episode_slug)
+    item = item_query.first_or_404()
+    if item:
+        return jsonify(item_details_schema.dump(item))
+    else:
+        return make_response("Item not found", 404, headers)

--- a/arcsi/api/__init__.py
+++ b/arcsi/api/__init__.py
@@ -16,11 +16,7 @@ def view_show_archive(show_slug):
     show_query = Show.query.filter_by(archive_lahmastore_base_url=show_slug)
     show = show_query.first_or_404()
     if show:
-        # filter_date = datetime.today() - timedelta(days=1)
-        # airing_date = Item.play_date
-        # filter_hour = datetime.now() - timedelta(days=1)
-        # airing_hour = show.start
-        show_items = show.items.filter(Item.play_date + show.start < datetime.now() - timedelta(days=1)).all()
+        show_items = show.items.filter(Item.play_date < datetime.today() - timedelta(days=1)).all()
         return jsonify(many_item_details_schema.dumps(show_items))
     else:
         return make_response("Show not found", 404, headers)

--- a/arcsi/api/__init__.py
+++ b/arcsi/api/__init__.py
@@ -9,25 +9,3 @@ from .user import *
 
 # TODO add routing here eg
 # arcsi.route("/archive", methods=["GET"])(<method_name>)
-
-
-@arcsi.route("show/<string:show_slug>/archive", methods=["GET"])
-def view_show_archive(show_slug):
-    show_query = Show.query.filter_by(archive_lahmastore_base_url=show_slug)
-    show = show_query.first_or_404()
-    if show:
-        show_items = show.items.filter(Item.play_date < datetime.today() - timedelta(days=1)).all()
-        return jsonify(many_item_details_schema.dumps(show_items))
-    else:
-        return make_response("Show not found", 404, headers)
-
-
-@arcsi.route("show/<string:show_slug>/episode/<string:episode_slug>", methods=["GET"])
-def view_episode_archive(show_slug, episode_slug):
-    episode_slug += ".mp3"
-    item_query = Show.query.filter_by(archive_lahmastore_base_url=show_slug).join(Item, Show.items).first().items.filter_by(play_file_name=episode_slug)
-    item = item_query.first_or_404()
-    if item:
-        return jsonify(item_details_schema.dump(item))
-    else:
-        return make_response("Item not found", 404, headers)

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -2,7 +2,6 @@ import json
 import os
 import requests
 import io
-from arcsi.model import secondary
 
 from mutagen.id3 import APIC, ID3
 from mutagen.mp3 import MP3
@@ -22,7 +21,6 @@ from arcsi.handler.upload import DoArchive
 from arcsi.model import db
 from arcsi.model.item import Item
 from arcsi.model.show import Show
-from arcsi.model.secondary import items_shows
 
 
 class ItemDetailsSchema(Schema):

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -402,14 +402,3 @@ def edit_item(id):
                 jsonify(item_details_partial_schema.dump(item)), 200, headers
             )
         return "Some error happened, check server logs for details. Note that your media may have been uploaded (to DO and/or Azurcast)."
-
-
-@arcsi.route("/<string:show_slug>/ep_<string:episode_slug>", methods=["GET"])
-def view_episode_archive(show_slug, episode_slug):
-    episode_slug += ".mp3"
-    item_query = Show.query.filter_by(archive_lahmastore_base_url=show_slug).join(Item, Show.items).first().items.filter_by(play_file_name=episode_slug)
-    item = item_query.first_or_404()
-    if item:
-        return jsonify(item_details_schema.dump(item))
-    else:
-        return make_response("Item not found", 404, headers)

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -2,6 +2,7 @@ import json
 import os
 import requests
 import io
+from arcsi.model import secondary
 
 from mutagen.id3 import APIC, ID3
 from mutagen.mp3 import MP3
@@ -21,6 +22,7 @@ from arcsi.handler.upload import DoArchive
 from arcsi.model import db
 from arcsi.model.item import Item
 from arcsi.model.show import Show
+from arcsi.model.secondary import items_shows
 
 
 class ItemDetailsSchema(Schema):
@@ -402,3 +404,15 @@ def edit_item(id):
                 jsonify(item_details_partial_schema.dump(item)), 200, headers
             )
         return "Some error happened, check server logs for details. Note that your media may have been uploaded (to DO and/or Azurcast)."
+
+
+@arcsi.route("/<string:show_slug>/<episode_number>", methods=["GET"])
+def view_episode_archive(show_slug, episode_number):
+    do = DoArchive()
+    # TODO instead of json filtering,
+    # write actual query
+    # joining shows and items
+    # so we can limit date etc.
+    item_query = Show.query.filter_by(archive_lahmastore_base_url=show_slug).join(Item, Show.items).filter_by(number=episode_number).first().items
+    item = item_query.first_or_404()
+    return jsonify(item_details_schema.dump(item))

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -404,13 +404,12 @@ def edit_item(id):
         return "Some error happened, check server logs for details. Note that your media may have been uploaded (to DO and/or Azurcast)."
 
 
-@arcsi.route("/<string:show_slug>/<episode_number>", methods=["GET"])
-def view_episode_archive(show_slug, episode_number):
-    do = DoArchive()
-    # TODO instead of json filtering,
-    # write actual query
-    # joining shows and items
-    # so we can limit date etc.
-    item_query = Show.query.filter_by(archive_lahmastore_base_url=show_slug).join(Item, Show.items).filter_by(number=episode_number).first().items
+@arcsi.route("/<string:show_slug>/ep_<string:episode_slug>", methods=["GET"])
+def view_episode_archive(show_slug, episode_slug):
+    episode_slug += ".mp3"
+    item_query = Show.query.filter_by(archive_lahmastore_base_url=show_slug).join(Item, Show.items).first().items.filter_by(play_file_name=episode_slug)
     item = item_query.first_or_404()
-    return jsonify(item_details_schema.dump(item))
+    if item:
+        return jsonify(item_details_schema.dump(item))
+    else:
+        return make_response("Item not found", 404, headers)

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -6,7 +6,6 @@ import io
 from datetime import datetime, timedelta
 from flask import flash, jsonify, make_response, request, url_for
 from flask import current_app as app
-from arcsi.api.item import ItemDetailsSchema
 from marshmallow import fields, post_load, Schema, ValidationError
 from werkzeug import secure_filename
 

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -6,6 +6,7 @@ import io
 from datetime import datetime, timedelta
 from flask import flash, jsonify, make_response, request, url_for
 from flask import current_app as app
+from arcsi.api.item import ItemDetailsSchema
 from marshmallow import fields, post_load, Schema, ValidationError
 from werkzeug import secure_filename
 
@@ -66,6 +67,9 @@ class ShowDetailsSchema(Schema):
 show_details_schema = ShowDetailsSchema()
 show_details_partial_schema = ShowDetailsSchema(partial=True)
 many_show_details_schema = ShowDetailsSchema(many=True)
+many_show_details_basic_schema = ShowDetailsSchema(many=True, only=("id", "active", "name", "description",
+"week", "day", "start", "end",
+"cover_image_url", "archive_lahmastore_base_url"))
 
 headers = {"Content-Type": "application/json"}
 
@@ -80,8 +84,7 @@ def list_shows():
             show.cover_image_url = do.download(
                 show.archive_lahmastore_base_url, show.cover_image_url
             )
-    return many_show_details_schema.dumps(shows)
-
+    return many_show_details_basic_schema.dumps(shows)
 
 @arcsi.route("/show/<id>", methods=["GET"])
 def view_show(id):

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -14,7 +14,6 @@ from .utils import archive, process, slug, sort_for
 from arcsi.api import arcsi
 from arcsi.handler.upload import DoArchive
 from arcsi.model import db
-from arcsi.model.item import Item
 from arcsi.model.show import Show
 from arcsi.model.user import User
 
@@ -67,9 +66,10 @@ class ShowDetailsSchema(Schema):
 show_details_schema = ShowDetailsSchema()
 show_details_partial_schema = ShowDetailsSchema(partial=True)
 many_show_details_schema = ShowDetailsSchema(many=True)
-many_show_details_basic_schema = ShowDetailsSchema(many=True, only=("id", "active", "name", "description",
-"week", "day", "start", "end",
-"cover_image_url", "archive_lahmastore_base_url"))
+many_show_details_basic_schema = ShowDetailsSchema(many=True, 
+                                                   only=("id", "active", "name", "description",
+                                                         "week", "day", "start", "end",
+                                                         "cover_image_url", "archive_lahmastore_base_url"))
 
 headers = {"Content-Type": "application/json"}
 

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -108,7 +108,7 @@ def view_show(id):
 
 
 @arcsi.route("/show/<string:slug>/archive", methods=["GET"])
-def view_archive(slug):
+def view_show_archive(slug):
     do = DoArchive()
     # TODO instead of json filtering,
     # write actual query

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -15,7 +15,6 @@ from arcsi.handler.upload import DoArchive
 from arcsi.model import db
 from arcsi.model.show import Show
 from arcsi.model.user import User
-from arcsi.api.item import many_item_details_schema
 
 
 class ShowDetailsSchema(Schema):
@@ -103,17 +102,6 @@ def view_show(id):
         serial_show["items"] = date_desc_episodes
 
         return serial_show
-    else:
-        return make_response("Show not found", 404, headers)
-
-
-@arcsi.route("/<string:show_slug>/archive", methods=["GET"])
-def view_show_archive(show_slug):
-    show_query = Show.query.filter_by(archive_lahmastore_base_url=show_slug)
-    show = show_query.first_or_404()
-    if show:
-        show_items = show.items
-        return jsonify(many_item_details_schema.dumps(show_items))
     else:
         return make_response("Show not found", 404, headers)
 

--- a/arcsi/view/item.py
+++ b/arcsi/view/item.py
@@ -47,6 +47,7 @@ def view_item(id):
 
 
 @router.route("/item/<id>/edit", methods=["GET"])
+@roles_accepted("admin", "host", "guest")
 def edit_item(id):
     relpath = url_for("arcsi.edit_item", id=id)
     item = requests.get(app.config["APP_BASE_URL"] + relpath)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
         - app.env
         - db.env
     # there is no `depend_on: condition:` in compose service v3
-    entrypoint: sh -c 'sleep 5; /app/entrypoint.sh'
+    entrypoint: sh -c 'sleep 60; /app/entrypoint.sh'
 
   db:
     image: postgres:12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
         - app.env
         - db.env
     # there is no `depend_on: condition:` in compose service v3
-    entrypoint: sh -c 'sleep 60; /app/entrypoint.sh'
+    entrypoint: sh -c 'sleep 5; /app/entrypoint.sh'
 
   db:
     image: postgres:12


### PR DESCRIPTION
#123 Improve arcsi rest endpoints
Minor improvements in arcsi rest endpoints

- `show/all` route now sends back the `shows` data without the `items` field (the sixth of the size before)
- added a new route `/show_slug/episode_number` where we can query the specified item directly
- I think we should modify our db a little bit, imo there should be a unique field in the `Item` model as well. Maybe that would help us against the duplicated records