### PR TITLE
Allow OPTIONS request in nginx config

### DIFF
--- a/nginx/https_arcsi.conf.template
+++ b/nginx/https_arcsi.conf.template
@@ -97,7 +97,7 @@ server {
 
         proxy_pass http://arcsi;
     }
-    if ( $request_method !~ ^(GET|POST|HEAD)$ ) {
+    if ( $request_method !~ ^(GET|POST|HEAD|OPTIONS)$ ) {
         return 405;
     }
 


### PR DESCRIPTION
The change attempts to fix the conflict with https://github.com/mmmnmnm/lahmacun_arcsi/blob/0f9bbc8ff36357f3e74a2212b7207bfade60efa7/nginx/https_arcsi.conf.template#L74-L76 

Following @pvj's advise (which was not to comment out the 405 rule because it's good to control what requests are allowed) I allowed the OPTIONS type requests in the rule in question. 

Disclaimer: I haven't tested locally because I thought it was a trivial change. We can test it on our dev server once merged (with the other ongoing tests). 