### PR TITLE
Dev/paginate and more effective routes

### DIFF
--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -7,6 +7,7 @@ from mutagen.id3 import APIC, ID3
 from mutagen.mp3 import MP3
 
 from flask import flash, jsonify, make_response, request, send_file, url_for, redirect
+from flask import current_app as app
 from marshmallow import fields, post_load, Schema, ValidationError
 
 from .utils import (
@@ -58,10 +59,14 @@ class ItemDetailsSchema(Schema):
 
 
 item_details_schema = ItemDetailsSchema()
-item_details_partial_schema = ItemDetailsSchema(
-    partial=True,
-)
+item_basic_details_schema = ItemDetailsSchema(only = ("name", "number", "play_date", "language", 
+                                             "description", "image_url", "play_file_name", "download_count"))
+item_details_partial_schema = ItemDetailsSchema(partial=True,)
 many_item_details_schema = ItemDetailsSchema(many=True)
+many_item_details_basic_schema = ItemDetailsSchema(many=True, 
+                                                   only=("name", "description",
+                                                         "play_date", "play_file_name",
+                                                         "image_url", "download_count"))
 
 headers = {"Content-Type": "application/json"}
 
@@ -76,7 +81,7 @@ def list_items():
             item.image_url = do.download(
                 item.shows[0].archive_lahmastore_base_url, item.image_url
             )
-    return many_item_details_schema.dumps(items)
+    return many_item_details_basic_schema.dumps(items)
 
 
 @arcsi.route("/item/<id>", methods=["GET"])

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -75,13 +75,15 @@ headers = {"Content-Type": "application/json"}
 @arcsi.route("/item/all", methods=["GET"])
 def list_items():
     do = DoArchive()
-    items = Item.query.all()
-    for item in items:
+    page = request.args.get('page', 1, type=int)
+    items = Item.query.order_by(Item.play_date.desc()).paginate(
+        page, app.config['PAGE_SIZE'], False)
+    for item in items.items:
         if item.image_url:
             item.image_url = do.download(
                 item.shows[0].archive_lahmastore_base_url, item.image_url
             )
-    return items_basic_schema.dumps(items)
+    return items_basic_schema.dumps(items.items)
 
 
 @arcsi.route("/item/<id>", methods=["GET"])

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -82,7 +82,7 @@ headers = {"Content-Type": "application/json"}
 
 
 @arcsi.route("/show", methods=["GET"])
-@arcsi.route("/shows/all", methods=["GET"])
+@arcsi.route("/show/all", methods=["GET"])
 def list_shows():
     do = DoArchive()
     shows = Show.query.all()
@@ -94,7 +94,7 @@ def list_shows():
     return shows_schedule_schema.dumps(shows)
 
 
-@arcsi.route("/shows/archive", methods=["GET"])
+@arcsi.route("/show/archive", methods=["GET"])
 def list_shows_archive():
     do = DoArchive()
     shows = Show.query.all()

--- a/arcsi/static/component.json
+++ b/arcsi/static/component.json
@@ -139,38 +139,34 @@
                     "$ref": "#/components/schemas/UserRequest"
                 }
             },
-            "ShowRequest": {
+            "ShowBasicRequest": {
                 "type": "object",
                 "properties": {
-                    "id": {
-                        "type": "integer",
-                        "format": "int32"
-                    },
                     "active": {
                         "type": "boolean"
                     },
                     "name": {
                         "type": "string"
                     },
+                    "cover_image_url": {
+                        "type": "string"
+                    },
                     "description": {
                         "type": "string"
                     },
-                    "language": {
+                    "archive_lahmastore_base_url": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ShowRequest": {
+                "type": "object",
+                "properties": {
+                    "name": {
                         "type": "string"
                     },
                     "cover_image_url": {
                         "type": "string"
-                    },
-                    "playlist_name": {
-                        "type": "string"
-                    },
-                    "frequency": {
-                        "type": "integer",
-                        "format": "int32"
-                    },
-                    "week": {
-                        "type": "integer",
-                        "format": "int32"
                     },
                     "day": {
                         "type": "integer",
@@ -182,30 +178,34 @@
                     "end": {
                         "type": "string"
                     },
+                    "frequency": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "language": {
+                        "type": "string"
+                    },
+                    "active": {
+                        "type": "boolean"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
                     "archive_lahmastore": {
                         "type": "boolean"
-                    },
-                    "archive_lahmastore_base_url": {
-                        "type": "string"
-                    },
-                    "archive_mixcloud": {
-                        "type": "boolean"
-                    },
-                    "archive_mixcloud_base_url": {
-                        "type": "string"
                     },
                     "items": {
                         "type": "object",
                         "additionalProperties": {
                             "$ref": "#/components/schemas/item"
                         }
-                    },
-                    "users": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/user"
-                        }
                     }
+                }
+            },
+            "ShowBasicRequests": {
+                "type": "object",
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/ShowBasicRequest"
                 }
             },
             "ShowRequests": {
@@ -303,24 +303,13 @@
                     "user_email": "arcsi@lahmacun.hu"
                 }
             },
-            "ItemRequest": {
+            "ItemBasicRequest": {
                 "type": "object",
                 "properties": {
-                    "id": {
-                        "type": "integer",
-                        "format": "int32"
-                    },
-                    "number": {
-                        "type": "integer",
-                        "format": "int32"
-                    },
                     "name": {
                         "type": "string"
                     },
                     "description": {
-                        "type": "string"
-                    },
-                    "language": {
                         "type": "string"
                     },
                     "play_date": {
@@ -332,44 +321,45 @@
                     },
                     "play_file_name": {
                         "type": "string"
-                    },
-                    "live": {
-                        "type": "boolean"
-                    },
-                    "broadcast": {
-                        "type": "boolean"
-                    },
-                    "airing": {
-                        "type": "boolean"
-                    },
-                    "archive_lahmastore": {
-                        "type": "boolean"
-                    },
-                    "archive_lahmastore_canonical_url": {
+                    }
+                }
+            },
+            "ItemRequest": {
+                "type": "object",
+                "properties": {
+                    "name": {
                         "type": "string"
                     },
-                    "archive_mixcloud": {
-                        "type": "boolean"
+                    "number": {
+                        "type": "integer",
+                        "format": "int32"
                     },
-                    "archive_mixcloud_canonical_url": {
+                    "play_date": {
+                        "type": "string",
+                        "format": "date"
+                    },
+                    "language": {
                         "type": "string"
                     },
-                    "archived": {
-                        "type": "boolean"
+                    "description": {
+                        "type": "string"
+                    },
+                    "image_url": {
+                        "type": "string"
+                    },
+                    "play_file_name": {
+                        "type": "string"
                     },
                     "download_count": {
                         "type": "integer",
                         "format": "int32"
-                    },
-                    "uploader": {
-                        "type": "string"
-                    },
-                    "shows": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/show"
-                        }
                     }
+                }
+            },
+            "ItemBasicRequests": {
+                "type": "object",
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/ItemBasicRequest"
                 }
             },
             "ItemRequests": {

--- a/arcsi/static/component.json
+++ b/arcsi/static/component.json
@@ -139,7 +139,37 @@
                     "$ref": "#/components/schemas/UserRequest"
                 }
             },
-            "ShowBasicRequest": {
+            "ShowScheduleRequest": {
+                "type": "object",
+                "properties": {
+                    "active": {
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "cover_image_url": {
+                        "type": "string"
+                    },
+                    "day": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "start": {
+                        "type": "string"
+                    },
+                    "end": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "archive_lahmastore_base_url": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ShowArchiveRequest": {
                 "type": "object",
                 "properties": {
                     "active": {
@@ -202,10 +232,16 @@
                     }
                 }
             },
-            "ShowBasicRequests": {
+            "ShowScheduleRequests": {
                 "type": "object",
                 "additionalProperties": {
-                    "$ref": "#/components/schemas/ShowBasicRequest"
+                    "$ref": "#/components/schemas/ShowScheduleRequest"
+                }
+            },
+            "ShowArchiveRequests": {
+                "type": "object",
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/ShowArchiveRequest"
                 }
             },
             "ShowRequests": {

--- a/arcsi/static/doc.json
+++ b/arcsi/static/doc.json
@@ -92,7 +92,7 @@
         }
       }
     },
-    "/show/all": {
+    "/shows/all": {
       "get": {
         "tags": [
           "Show Request"
@@ -107,7 +107,7 @@
             "content": {
               "text/html": {
                 "schema": {
-                  "$ref": "component.json#/components/schemas/ShowRequests"
+                  "$ref": "component.json#/components/schemas/ShowBasicRequests"
                 }
               }
             }
@@ -115,80 +115,18 @@
         }
       }
     },
-    "/show/{id}": {
+    "/show/{show_slug}": {
       "get": {
         "tags": [
           "Show Request"
         ],
-        "summary": "Get Show with given ID",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "description": "ID of the show that we want to match",
-            "schema": {
-              "$ref": "component.json#/components/schemas/id"
-            }
-          }
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "component.json#/components/schemas/ShowRequest"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Show not found"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Show Request"
-        ],
-        "summary": "Delete Show with given ID",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "description": "ID of the show that we want to delete",
-            "schema": {
-              "$ref": "component.json#/components/schemas/id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Deleted show successfully"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/show/{show_slug}/archive": {
-      "get": {
-        "tags": [
-          "Show Request"
-        ],
-        "summary": "Get Show with given URL",
+        "summary": "Get Show subpage infos with Show slug",
         "parameters": [
           {
             "in": "path",
             "name": "show_slug",
             "required": true,
-            "description": "Show's archive_lahmastore_base_url",
+            "description": "Show.archive_lahmastore_base_url",
             "type": "string"
           }
         ],
@@ -201,7 +139,7 @@
             "content": {
               "text/html": {
                 "schema": {
-                  "$ref": "component.json#/components/schemas/ItemRequests"
+                  "$ref": "component.json#/components/schemas/ShowRequest"
                 }
               }
             }
@@ -217,20 +155,20 @@
         "tags": [
           "Item Request"
         ],
-        "summary": "Get Item with given URL",
+        "summary": "Get Episode with Episode slug",
         "parameters": [
           {
             "in": "path",
             "name": "show_slug",
             "required": true,
-            "description": "Show's archive_lahmastore_base_url",
+            "description": "Show.archive_lahmastore_base_url",
             "type": "string"
           },
           {
             "in": "path",
             "name": "episode_slug",
             "required": true,
-            "description": "Item's play_file_name without the .mp3 extension",
+            "description": "Item.play_file_name + '.mp3'",
             "type": "string"
           }
         ],

--- a/arcsi/static/doc.json
+++ b/arcsi/static/doc.json
@@ -115,14 +115,23 @@
         }
       }
     },
-    "/show/archive": {
+    "/show/{id}": {
       "get": {
         "tags": [
           "Show Request"
         ],
         "summary": "Return Shows for Shows Page",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "description": "Show.id",
+            "type": "string"
+          }
+        ],
         "produces": [
-          "text/html"
+          "application/json"
         ],
         "responses": {
           "200": {
@@ -130,7 +139,7 @@
             "content": {
               "text/html": {
                 "schema": {
-                  "$ref": "component.json#/components/schemas/ShowArchiveRequests"
+                  "$ref": "component.json#/components/schemas/ItemRequest"
                 }
               }
             }
@@ -154,7 +163,7 @@
           }
         ],
         "produces": [
-          "text/html"
+          "application/json"
         ],
         "responses": {
           "200": {

--- a/arcsi/static/doc.json
+++ b/arcsi/static/doc.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "description": "Arcsi API doc",
-    "version": "0.9.4",
+    "version": "0.9.5",
     "title": "Arcsi",
     "contact": {
       "email": "it@lahmacun.hu"
@@ -97,7 +97,7 @@
         "tags": [
           "Show Request"
         ],
-        "summary": "Return all Show",
+        "summary": "Return Shows for Home and Schedule Page",
         "produces": [
           "text/html"
         ],
@@ -107,7 +107,7 @@
             "content": {
               "text/html": {
                 "schema": {
-                  "$ref": "component.json#/components/schemas/ShowBasicRequests"
+                  "$ref": "component.json#/components/schemas/ShowScheduleRequests"
                 }
               }
             }
@@ -115,12 +115,35 @@
         }
       }
     },
-    "/show/{show_slug}": {
+    "/shows/archive": {
       "get": {
         "tags": [
           "Show Request"
         ],
-        "summary": "Get Show subpage infos with Show slug",
+        "summary": "Return Shows for Shows Page",
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "$ref": "component.json#/components/schemas/ShowArchiveRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/show/{show_slug}/archive": {
+      "get": {
+        "tags": [
+          "Show Request"
+        ],
+        "summary": "Return Show for Show Subpage",
         "parameters": [
           {
             "in": "path",
@@ -155,7 +178,7 @@
         "tags": [
           "Item Request"
         ],
-        "summary": "Get Episode with Episode slug",
+        "summary": "Return Episode for Episode Subpage",
         "parameters": [
           {
             "in": "path",
@@ -197,7 +220,7 @@
         "tags": [
           "Item Request"
         ],
-        "summary": "Return all Item",
+        "summary": "Return Episodes for Archive Page",
         "produces": [
           "text/html"
         ],

--- a/arcsi/static/doc.json
+++ b/arcsi/static/doc.json
@@ -92,7 +92,7 @@
         }
       }
     },
-    "/shows/all": {
+    "/show/all": {
       "get": {
         "tags": [
           "Show Request"
@@ -115,7 +115,7 @@
         }
       }
     },
-    "/shows/archive": {
+    "/show/archive": {
       "get": {
         "tags": [
           "Show Request"

--- a/config.template.py
+++ b/config.template.py
@@ -45,3 +45,5 @@ else:
 
 PORT = 5666  # The application port nginx proxy is passing to
 APP_BASE_URL = "http://{}:{}".format(HOST, PORT)
+
+PAGE_SIZE = 12


### PR DESCRIPTION
Added pagination for the `/item/all` route #128 
Made a lot of optimizations in the API calls, to only return the neccessary data
Updated Swagger to make it more intuitive and readable for front-end developers