### PR TITLE
Fix/Updated API endpoints and Swagger doc

### DIFF
--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -59,11 +59,11 @@ class ItemDetailsSchema(Schema):
 
 
 item_schema = ItemDetailsSchema()
-item_archive_schema = ItemDetailsSchema(only = ("name", "number", "play_date", "language", 
+item_minimal_schema = ItemDetailsSchema(only = ("name", "number", "play_date", "language", 
                                              "description", "image_url", "play_file_name", "download_count"))
 item_partial_schema = ItemDetailsSchema(partial=True,)
 items_schema = ItemDetailsSchema(many=True)
-items_basic_schema = ItemDetailsSchema(many=True, 
+items_minimal_schema = ItemDetailsSchema(many=True, 
                                                    only=("name", "description",
                                                          "play_date", "play_file_name",
                                                          "image_url", "download_count"))
@@ -75,15 +75,27 @@ headers = {"Content-Type": "application/json"}
 @arcsi.route("/item/all", methods=["GET"])
 def list_items():
     do = DoArchive()
+    items = Item.query.all()
+    for item in items:
+        if item.image_url:
+            item.image_url = do.download(
+                item.shows[0].archive_lahmastore_base_url, item.image_url
+            )
+    return items_schema.dumps(items)
+
+@arcsi.route("/item/all_minimal/", methods=["GET"])
+def list_items_minimal():
+    do = DoArchive()
     page = request.args.get('page', 1, type=int)
+    size = request.args.get('size', 12, type=int)
     items = Item.query.order_by(Item.play_date.desc()).paginate(
-        page, app.config['PAGE_SIZE'], False)
+        page, size, False)
     for item in items.items:
         if item.image_url:
             item.image_url = do.download(
                 item.shows[0].archive_lahmastore_base_url, item.image_url
             )
-    return items_basic_schema.dumps(items.items)
+    return items_minimal_schema.dumps(items.items)
 
 
 @arcsi.route("/item/<id>", methods=["GET"])

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -59,11 +59,11 @@ class ItemDetailsSchema(Schema):
 
 
 item_schema = ItemDetailsSchema()
-item_minimal_schema = ItemDetailsSchema(only = ("name", "number", "play_date", "language", 
+item_archive_schema = ItemDetailsSchema(only = ("name", "number", "play_date", "language", 
                                              "description", "image_url", "play_file_name", "download_count"))
 item_partial_schema = ItemDetailsSchema(partial=True,)
 items_schema = ItemDetailsSchema(many=True)
-items_minimal_schema = ItemDetailsSchema(many=True, 
+items_archive_schema = ItemDetailsSchema(many=True, 
                                                    only=("name", "description",
                                                          "play_date", "play_file_name",
                                                          "image_url", "download_count"))
@@ -83,8 +83,8 @@ def list_items():
             )
     return items_schema.dumps(items)
 
-@arcsi.route("/item/all_minimal/", methods=["GET"])
-def list_items_minimal():
+@arcsi.route("/item/all_latest/", methods=["GET"])
+def list_items_latest():
     do = DoArchive()
     page = request.args.get('page', 1, type=int)
     size = request.args.get('size', 12, type=int)
@@ -95,7 +95,7 @@ def list_items_minimal():
             item.image_url = do.download(
                 item.shows[0].archive_lahmastore_base_url, item.image_url
             )
-    return items_minimal_schema.dumps(items.items)
+    return items_archive_schema.dumps(items.items)
 
 
 @arcsi.route("/item/<id>", methods=["GET"])

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -83,7 +83,7 @@ def list_items():
             )
     return items_schema.dumps(items)
 
-@arcsi.route("/item/all_latest/", methods=["GET"])
+@arcsi.route("/item/latest/", methods=["GET"])
 def list_items_latest():
     do = DoArchive()
     page = request.args.get('page', 1, type=int)

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -86,6 +86,7 @@ headers = {"Content-Type": "application/json"}
 
 
 @arcsi.route("/show", methods=["GET"])
+# We use this route on the legacy for a massive shows query
 @arcsi.route("/show/all", methods=["GET"])
 def list_shows():
     return shows_schema.dumps(get_shows)
@@ -94,8 +95,8 @@ def list_shows():
 def list_shows_for_schedule():
     return shows_schedule_schema.dumps(get_shows)
 
-
-@arcsi.route("/show/subpages", methods=["GET"])
+# We are gonna use this on the new page as the show/all
+@arcsi.route("/show/list", methods=["GET"])
 def list_shows_page():
     return shows_archive_schema.dumps(get_shows)
 
@@ -306,7 +307,7 @@ def view_show_archive(show_slug):
     #    return make_response("Show episodes not found", 404, headers)
 
 # This will be the one that we are gonna use at the new page 
-@arcsi.route("show/<string:show_slug>/subpages", methods=["GET"])
+@arcsi.route("show/<string:show_slug>/page", methods=["GET"])
 def view_show_page(show_slug):
     show_query = Show.query.filter_by(archive_lahmastore_base_url=show_slug)
     show = show_query.first()

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -9,7 +9,7 @@ from flask import current_app as app
 from marshmallow import fields, post_load, Schema, ValidationError
 from werkzeug import secure_filename
 
-from .utils import archive, process, slug, sort_for
+from .utils import archive, get_shows, process, slug, sort_for
 from arcsi.api import arcsi
 from arcsi.handler.upload import DoArchive
 from arcsi.model import db
@@ -88,37 +88,16 @@ headers = {"Content-Type": "application/json"}
 @arcsi.route("/show", methods=["GET"])
 @arcsi.route("/show/all", methods=["GET"])
 def list_shows():
-    do = DoArchive()
-    shows = Show.query.all()
-    for show in shows:
-        if show.cover_image_url:
-            show.cover_image_url = do.download(
-                show.archive_lahmastore_base_url, show.cover_image_url
-            )
-    return shows_schema.dumps(shows)
+    return shows_schema.dumps(get_shows)
 
-@arcsi.route("/show/all_schedule", methods=["GET"])
+@arcsi.route("/show/schedule", methods=["GET"])
 def list_shows_for_schedule():
-    do = DoArchive()
-    shows = Show.query.all()
-    for show in shows:
-        if show.cover_image_url:
-            show.cover_image_url = do.download(
-                show.archive_lahmastore_base_url, show.cover_image_url
-            )
-    return shows_schedule_schema.dumps(shows)
+    return shows_schedule_schema.dumps(get_shows)
 
 
-@arcsi.route("/show/all_page", methods=["GET"])
+@arcsi.route("/show/subpages", methods=["GET"])
 def list_shows_page():
-    do = DoArchive()
-    shows = Show.query.all()
-    for show in shows:
-        if show.cover_image_url:
-            show.cover_image_url = do.download(
-                show.archive_lahmastore_base_url, show.cover_image_url
-            )
-    return shows_archive_schema.dumps(shows)
+    return shows_archive_schema.dumps(get_shows)
 
 # TODO /item/<uuid>/add route so that each upload has unique id to begin with
 # no need for different methods for `POST` & `PUT`
@@ -327,7 +306,7 @@ def view_show_archive(show_slug):
     #    return make_response("Show episodes not found", 404, headers)
 
 # This will be the one that we are gonna use at the new page 
-@arcsi.route("show/<string:show_slug>/page", methods=["GET"])
+@arcsi.route("show/<string:show_slug>/subpages", methods=["GET"])
 def view_show_page(show_slug):
     show_query = Show.query.filter_by(archive_lahmastore_base_url=show_slug)
     show = show_query.first()

--- a/arcsi/api/utils.py
+++ b/arcsi/api/utils.py
@@ -141,3 +141,13 @@ def archive(archive_base, archive_file_name, archive_idx):
     archive_url = do.upload(archive_file_path, archive_base, archive_idx)
 
     return archive_url
+
+def get_shows():
+    do = DoArchive()
+    shows = Show.query.all()
+    for show in shows:
+        if show.cover_image_url:
+            show.cover_image_url = do.download(
+                show.archive_lahmastore_base_url, show.cover_image_url
+            )
+    return shows

--- a/arcsi/static/component.json
+++ b/arcsi/static/component.json
@@ -189,7 +189,7 @@
                     }
                 }
             },
-            "ShowRequest": {
+            "ShowSubPageRequest": {
                 "type": "object",
                 "properties": {
                     "name": {
@@ -221,8 +221,67 @@
                     "description": {
                         "type": "string"
                     },
-                    "archive_lahmastore": {
+                    "archive_lahmastore_base_url": {
+                        "type": "string"
+                    },
+                    "playlist_name": {
+                        "type": "string"
+                    },
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/ItemBasicRequest"
+                        }
+                    }
+                }
+            },
+            "ShowRequest": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "active": {
                         "type": "boolean"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "cover_image_url": {
+                        "type": "string"
+                    },
+                    "language": {
+                        "type": "string"
+                    },
+                    "playlist_name": {
+                        "type": "string"
+                    },
+                    "frequency": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "day": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "start": {
+                        "type": "string"
+                    },
+                    "end": {
+                        "type": "string"
+                    },
+                    "archive_lahmastore_base_url": {
+                        "type": "string"
+                    },
+                    "users": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/user"
+                        }
                     },
                     "items": {
                         "type": "object",
@@ -339,21 +398,88 @@
                     "user_email": "arcsi@lahmacun.hu"
                 }
             },
-            "ItemBasicRequest": {
+            "ItemArchiveRequest": {
                 "type": "object",
                 "properties": {
                     "name": {
-                        "type": "string"
-                    },
-                    "description": {
                         "type": "string"
                     },
                     "play_date": {
                         "type": "string",
                         "format": "date"
                     },
+                    "description": {
+                        "type": "string"
+                    },
                     "image_url": {
                         "type": "string"
+                    },
+                    "play_file_name": {
+                        "type": "string"
+                    },
+                    "download_count": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "shows": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/ShowArchiveRequest"
+                        }
+                    }
+                }
+            },
+            "ItemSubPageRequest": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "number": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "play_date": {
+                        "type": "string",
+                        "format": "date"
+                    },
+                    "language": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "image_url": {
+                        "type": "string"
+                    },
+                    "play_file_name": {
+                        "type": "string"
+                    },
+                    "download_count": {
+                        "type": "integer",
+                        "format": "int32"
+                    }
+                }
+            },
+            "ItemBasicRequest": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "image_url": {
+                        "type": "string"
+                    },
+                    "play_date": {
+                        "type": "string",
+                        "format": "date"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "download_count": {
+                        "type": "integer",
+                        "format": "int32"
                     },
                     "play_file_name": {
                         "type": "string"
@@ -389,7 +515,34 @@
                     "download_count": {
                         "type": "integer",
                         "format": "int32"
+                    },
+                    "live": {
+                        "type":"boolean"
+                    },
+                    "broadcast": {
+                        "type":"boolean"
+                    },
+                    "archive_lahmastore_base_url": {
+                        "type": "string"
+                    },
+                    "shows": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/ShowArchiveRequest"
+                        }
+                    },
+                    "users": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/user"
+                        }
                     }
+                }
+            },
+            "ItemArchiveRequests": {
+                "type": "object",
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/ItemBasicRequest"
                 }
             },
             "ItemBasicRequests": {

--- a/arcsi/static/doc.json
+++ b/arcsi/static/doc.json
@@ -37,7 +37,7 @@
         "tags": [
           "User Request"
         ],
-        "summary": "Return all User",
+        "summary": "Return Users for Arcsi",
         "produces": [
           "text/html"
         ],
@@ -60,7 +60,7 @@
         "tags": [
           "User Request"
         ],
-        "summary": "Get User with given ID",
+        "summary": "Return User for Arcsi",
         "parameters": [
           {
             "in": "path",
@@ -97,7 +97,30 @@
         "tags": [
           "Show Request"
         ],
-        "summary": "Return Shows for Home and Schedule Page",
+        "summary": "Return Shows for Arcsi Show Archive",
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "$ref": "component.json#/components/schemas/ShowRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/show/all_schedule": {
+      "get": {
+        "tags": [
+          "Show Request"
+        ],
+        "summary": "Return Shows for Ananasz Home and Schedule Page",
         "produces": [
           "text/html"
         ],
@@ -115,12 +138,35 @@
         }
       }
     },
+    "/show/all_minimal": {
+      "get": {
+        "tags": [
+          "Show Request"
+        ],
+        "summary": "Return Shows for Ananasz Shows Page",
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "$ref": "component.json#/components/schemas/ShowArchiveRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/show/{id}": {
       "get": {
         "tags": [
           "Show Request"
         ],
-        "summary": "Return Shows for Shows Page",
+        "summary": "Return Show for Arcsi Show Page",
         "parameters": [
           {
             "in": "path",
@@ -139,7 +185,7 @@
             "content": {
               "text/html": {
                 "schema": {
-                  "$ref": "component.json#/components/schemas/ItemRequest"
+                  "$ref": "component.json#/components/schemas/ShowRequest"
                 }
               }
             }
@@ -150,9 +196,44 @@
     "/show/{show_slug}/archive": {
       "get": {
         "tags": [
+          "Item Request"
+        ],
+        "summary": "Return Items for old WP Show Page",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "show_slug",
+            "required": true,
+            "description": "Show.archive_lahmastore_base_url",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "$ref": "component.json#/components/schemas/ItemBasicRequests"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Show not found"
+          }
+        }
+      }
+    },
+    "/show/{show_slug}/minimal": {
+      "get": {
+        "tags": [
           "Show Request"
         ],
-        "summary": "Return Show for Show Subpage",
+        "summary": "Return Show for Ananasz Show Subpage",
         "parameters": [
           {
             "in": "path",
@@ -171,7 +252,7 @@
             "content": {
               "text/html": {
                 "schema": {
-                  "$ref": "component.json#/components/schemas/ShowRequest"
+                  "$ref": "component.json#/components/schemas/ShowSubPageRequest"
                 }
               }
             }
@@ -187,7 +268,7 @@
         "tags": [
           "Item Request"
         ],
-        "summary": "Return Episode for Episode Subpage",
+        "summary": "Return Episode for Ananasz Episode Subpage",
         "parameters": [
           {
             "in": "path",
@@ -213,7 +294,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "component.json#/components/schemas/ItemRequest"
+                  "$ref": "component.json#/components/schemas/ItemSubPageRequest"
                 }
               }
             }
@@ -229,7 +310,7 @@
         "tags": [
           "Item Request"
         ],
-        "summary": "Return Episodes for Archive Page",
+        "summary": "Return Episodes for Arcsi Items Archive",
         "produces": [
           "text/html"
         ],
@@ -247,12 +328,51 @@
         }
       }
     },
+    "/item/all_minimal/?size={size}&?page={page}": {
+      "get": {
+        "tags": [
+          "Item Request"
+        ],
+        "summary": "Return Latest Episodes for Ananasz Home and Archive Page",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "size",
+            "required": true,
+            "description": "page_size, default: 12",
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "page",
+            "required": true,
+            "description": "page_number, default: 1",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "$ref": "component.json#/components/schemas/ItemArchiveRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/item/{id}": {
       "get": {
         "tags": [
           "Item Request"
         ],
-        "summary": "Get Item with given ID",
+        "summary": "Return Episode for Arcsi Episode Page",
         "parameters": [
           {
             "in": "path",

--- a/arcsi/static/doc.json
+++ b/arcsi/static/doc.json
@@ -138,7 +138,7 @@
         }
       }
     },
-    "/show/subpages": {
+    "/show/list": {
       "get": {
         "tags": [
           "Show Request"
@@ -228,7 +228,7 @@
         }
       }
     },
-    "/show/{show_slug}/subpages": {
+    "/show/{show_slug}/page": {
       "get": {
         "tags": [
           "Show Request"

--- a/arcsi/static/doc.json
+++ b/arcsi/static/doc.json
@@ -115,7 +115,7 @@
         }
       }
     },
-    "/show/all_schedule": {
+    "/show/schedule": {
       "get": {
         "tags": [
           "Show Request"
@@ -138,7 +138,7 @@
         }
       }
     },
-    "/show/all_page": {
+    "/show/subpages": {
       "get": {
         "tags": [
           "Show Request"
@@ -228,7 +228,7 @@
         }
       }
     },
-    "/show/{show_slug}/page": {
+    "/show/{show_slug}/subpages": {
       "get": {
         "tags": [
           "Show Request"
@@ -328,7 +328,7 @@
         }
       }
     },
-    "/item/all_latest/?size={size}&?page={page}": {
+    "/item/latest/?size={size}&?page={page}": {
       "get": {
         "tags": [
           "Item Request"

--- a/arcsi/static/doc.json
+++ b/arcsi/static/doc.json
@@ -138,7 +138,7 @@
         }
       }
     },
-    "/show/all_minimal": {
+    "/show/all_page": {
       "get": {
         "tags": [
           "Show Request"
@@ -228,7 +228,7 @@
         }
       }
     },
-    "/show/{show_slug}/minimal": {
+    "/show/{show_slug}/page": {
       "get": {
         "tags": [
           "Show Request"
@@ -328,7 +328,7 @@
         }
       }
     },
-    "/item/all_minimal/?size={size}&?page={page}": {
+    "/item/all_latest/?size={size}&?page={page}": {
       "get": {
         "tags": [
           "Item Request"

--- a/config.template.py
+++ b/config.template.py
@@ -45,5 +45,3 @@ else:
 
 PORT = 5666  # The application port nginx proxy is passing to
 APP_BASE_URL = "http://{}:{}".format(HOST, PORT)
-
-PAGE_SIZE = 12


### PR DESCRIPTION
In the previous PR, I forget about Arcsi's view methods & internal pages.
I restored the routes that were used by these features mentioned before.
The Swagger doc is more expressive than ever, it explains the exact use case and responses for every call.
Added the page size parameter for `/item/all_minimal/`
#128 