### PR TITLE
Create new file name in case filename already exists

### DIFF
--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -185,7 +185,7 @@ def add_item():
             # Defend against possible duplicate files
             if name_occurrence:
                 version_prefix = uuid4()
-                item_name = "{}-{}".format(version_prefix, new_item.name)
+                item_name = "{}-{}".format(new_item.name,version_prefix)
             else:
                 item_name = new_item.name
 
@@ -371,7 +371,7 @@ def edit_item(id):
             # Defend against possible duplicate files
             if name_occurrence:
                 version_prefix = uuid4()
-                item_name = "{}-{}".format(version_prefix, item.name)
+                item_name = "{}-{}".format(item.name,version_prefix)
             else:
                 item_name = item.name
 

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -175,7 +175,7 @@ def add_item():
         )
 
         name_occurrence = int(db.session.query(db.func.count()).filter(new_item.name == Item.name, new_item.number == Item.number).scalar())
-        app.logger.debug("Name_occurence (duplicate detection before flush): {}".format(name_occurrence))
+        app.logger.debug("Name_occurence (duplicate detection): {}".format(name_occurrence))
 
         db.session.add(new_item)
         db.session.flush()
@@ -183,9 +183,6 @@ def add_item():
         # TODO get show cover img and set as fallback
         if request.files:
             # Defend against possible duplicate files
-            name_occurrence = int(db.session.query(db.func.count()).filter(new_item.name == Item.name, new_item.number == Item.number).scalar())
-            app.logger.debug("Name_occurence (duplicate detection): {}".format(name_occurrence))
-
             if name_occurrence:
                 version_prefix = uuid4()
                 item_name = "{}-{}".format(version_prefix, new_item.name)
@@ -365,16 +362,13 @@ def edit_item(id):
         )
         
         name_occurrence = int(db.session.query(db.func.count()).filter(item.name == Item.name, item.number == Item.number).scalar())
-        app.logger.debug("Name_occurence (duplicate detection before flush): {}".format(name_occurrence))
+        app.logger.debug("Name_occurence (duplicate detection): {}".format(name_occurrence))
         
         db.session.add(item)
         db.session.flush()
 
         if request.files:
             # Defend against possible duplicate files
-            name_occurrence = int(db.session.query(db.func.count()).filter(new_item.name == Item.name, new_item.number == Item.number).scalar())
-            app.logger.debug("Name_occurence (duplicate detection): {}".format(name_occurrence))
-
             if name_occurrence:
                 version_prefix = uuid4()
                 item_name = "{}-{}".format(version_prefix, item.name)

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -174,6 +174,9 @@ def add_item():
             shows=shows,
         )
 
+        name_occurrence = int(db.session.query(db.func.count()).filter(new_item.name == Item.name, new_item.number == Item.number).scalar())
+        app.logger.debug("Name_occurence (duplicate detection before flush): {}".format(name_occurrence))
+
         db.session.add(new_item)
         db.session.flush()
 
@@ -181,7 +184,7 @@ def add_item():
         if request.files:
             # Defend against possible duplicate files
             name_occurrence = int(db.session.query(db.func.count()).filter(new_item.name == Item.name, new_item.number == Item.number).scalar())
-            version_pre = None
+            app.logger.debug("Name_occurence (duplicate detection): {}".format(name_occurrence))
 
             if name_occurrence:
                 version_prefix = uuid4()
@@ -360,13 +363,17 @@ def edit_item(id):
             .filter(Show.id.in_((show.id for show in item_metadata.shows)))
             .all()
         )
+        
+        name_occurrence = int(db.session.query(db.func.count()).filter(item.name == Item.name, item.number == Item.number).scalar())
+        app.logger.debug("Name_occurence (duplicate detection before flush): {}".format(name_occurrence))
+        
         db.session.add(item)
         db.session.flush()
 
         if request.files:
             # Defend against possible duplicate files
-            name_occurrence = int(db.session.query(db.func.count()).filter(item.name == Item.name, item.number == Item.number).scalar())
-            version_pre = None
+            name_occurrence = int(db.session.query(db.func.count()).filter(new_item.name == Item.name, new_item.number == Item.number).scalar())
+            app.logger.debug("Name_occurence (duplicate detection): {}".format(name_occurrence))
 
             if name_occurrence:
                 version_prefix = uuid4()

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -198,7 +198,7 @@ def add_item():
                         archive_base=new_item.shows[0].archive_lahmastore_base_url,
                         archive_idx=new_item.number,
                         archive_file=play_file,
-                        archive_name=(new_item.shows[0].name, item_name),
+                        archive_file_name=(new_item.shows[0].name, item_name),
                     )
 
             if request.files["image_file"]:
@@ -209,7 +209,7 @@ def add_item():
                         archive_base=new_item.shows[0].archive_lahmastore_base_url,
                         archive_idx=new_item.number,
                         archive_file=image_file,
-                        archive_name=(new_item.shows[0].name, item_name),
+                        archive_file_name=(new_item.shows[0].name, item_name),
                     )
 
             if new_item.broadcast:
@@ -383,7 +383,7 @@ def edit_item(id):
                         archive_base=item.shows[0].archive_lahmastore_base_url,
                         archive_idx=item.number,
                         archive_file=image_file,
-                        archive_name=(item.shows[0].name, item_name),
+                        archive_file_name=(item.shows[0].name, item_name),
                     )
 
             if request.files["play_file"]:
@@ -394,7 +394,7 @@ def edit_item(id):
                         archive_base=item.shows[0].archive_lahmastore_base_url,
                         archive_idx=item.number,
                         archive_file=play_file,
-                        archive_name=(item.shows[0].name, item_name),
+                        archive_file_name=(item.shows[0].name, item_name),
                     )
             if item.broadcast:
                 # we require both image and audio if broadcast (Azuracast) is set

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -310,7 +310,7 @@ def view_show_archive(show_slug):
     #    return make_response("Show episodes not found", 404, headers)
 
 # This will be the one that we are gonna use at the new page 
-@arcsi.route("show/<string:show_slug>/subpages", methods=["GET"])
+@arcsi.route("show/<string:show_slug>/page", methods=["GET"])
 def view_show_page(show_slug):
     show_query = Show.query.filter_by(archive_lahmastore_base_url=show_slug)
     show = show_query.first()

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -310,7 +310,7 @@ def view_show_archive(show_slug):
     #    return make_response("Show episodes not found", 404, headers)
 
 # This will be the one that we are gonna use at the new page 
-@arcsi.route("show/<string:show_slug>/page", methods=["GET"])
+@arcsi.route("show/<string:show_slug>/subpages", methods=["GET"])
 def view_show_page(show_slug):
     show_query = Show.query.filter_by(archive_lahmastore_base_url=show_slug)
     show = show_query.first()

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -9,11 +9,7 @@ from flask import current_app as app
 from marshmallow import fields, post_load, Schema, ValidationError
 from werkzeug import secure_filename
 
-<<<<<<< HEAD
-from .utils import archive, get_shows, process, slug, sort_for
-=======
-from .utils import archive, save_file, slug, sort_for
->>>>>>> 45c5145 (fix(api): Create new filenames on reupload)
+from .utils import archive, get_shows, save_file, slug, sort_for
 from arcsi.api import arcsi
 from arcsi.handler.upload import DoArchive
 from arcsi.model import db
@@ -289,7 +285,7 @@ def view_show(id):
 def view_show_archive(show_slug):
     do = DoArchive()
     show_query = Show.query.filter_by(archive_lahmastore_base_url=show_slug)
-    show = show_query.first_or_404()
+    show = show_query.first()
     if show:
         show_json = show_schema.dump(show)
         show_items = [

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -9,7 +9,11 @@ from flask import current_app as app
 from marshmallow import fields, post_load, Schema, ValidationError
 from werkzeug import secure_filename
 
+<<<<<<< HEAD
 from .utils import archive, get_shows, process, slug, sort_for
+=======
+from .utils import archive, save_file, slug, sort_for
+>>>>>>> 45c5145 (fix(api): Create new filenames on reupload)
 from arcsi.api import arcsi
 from arcsi.handler.upload import DoArchive
 from arcsi.model import db
@@ -158,7 +162,7 @@ def add_show():
 
         if request.files:
             if request.files["image_file"]:
-                cover_image_name = process(
+                cover_image_name = save_file(
                     archive_base=new_show.archive_lahmastore_base_url,
                     archive_idx=0,
                     archive_file=request.files["image_file"],
@@ -242,7 +246,7 @@ def edit_show(id):
 
         if request.files:
             if request.files["image_file"]:
-                cover_image_name = process(
+                cover_image_name = save_file(
                     archive_base=show.archive_lahmastore_base_url,
                     archive_idx=0,
                     archive_file=request.files["image_file"],

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -162,7 +162,7 @@ def add_show():
                     archive_base=new_show.archive_lahmastore_base_url,
                     archive_idx=0,
                     archive_file=request.files["image_file"],
-                    archive_name=(new_show.name, "cover"),
+                    archive_file_name=(new_show.name, "cover"),
                 )
                 if cover_image_name:
                     new_show.cover_image_url = archive(
@@ -246,7 +246,7 @@ def edit_show(id):
                     archive_base=show.archive_lahmastore_base_url,
                     archive_idx=0,
                     archive_file=request.files["image_file"],
-                    archive_name=(show.name, "cover"),
+                    archive_file_name=(show.name, "cover"),
                 )
                 if cover_image_name:
                     show.cover_image_url = archive(

--- a/arcsi/api/utils.py
+++ b/arcsi/api/utils.py
@@ -119,19 +119,19 @@ def broadcast_audio(
     return False
 
 
-def process(archive_base, archive_idx, archive_file, archive_name):
-    archive_file_name = form_filename(archive_file, archive_name)
+def save_file(archive_base, archive_idx, archive_file, archive_file_name):
+    formed_file_name = form_filename(archive_file, archive_file_name)
     if not allowed_file(archive_file_name):
         return None
     else:
-        if archive_file_name == "":
+        if formed_file_name == "":
             return None
         else:
             archive_file_path = media_path(
-                archive_base, str(archive_idx), archive_file_name
+                archive_base, str(archive_idx), formed_file_name
             )
             archive_file.save(archive_file_path)
-            return archive_file_name
+            return formed_file_name
 
 
 def archive(archive_base, archive_file_name, archive_idx):

--- a/arcsi/api/utils.py
+++ b/arcsi/api/utils.py
@@ -121,7 +121,7 @@ def broadcast_audio(
 
 def save_file(archive_base, archive_idx, archive_file, archive_file_name):
     formed_file_name = form_filename(archive_file, archive_file_name)
-    if not allowed_file(archive_file_name):
+    if not allowed_file(formed_file_name):
         return None
     else:
         if formed_file_name == "":

--- a/arcsi/static/doc.json
+++ b/arcsi/static/doc.json
@@ -92,7 +92,7 @@
         }
       }
     },
-    "/shows/all": {
+    "/show/all": {
       "get": {
         "tags": [
           "Show Request"
@@ -107,7 +107,7 @@
             "content": {
               "text/html": {
                 "schema": {
-                  "$ref": "component.json#/components/schemas/ShowBasicRequests"
+                  "$ref": "component.json#/components/schemas/ShowRequests"
                 }
               }
             }
@@ -228,7 +228,7 @@
         }
       }
     },
-    "/show/{show_slug}/subpages": {
+    "/show/{show_slug}/page": {
       "get": {
         "tags": [
           "Show Request"

--- a/arcsi/static/doc.json
+++ b/arcsi/static/doc.json
@@ -92,7 +92,7 @@
         }
       }
     },
-    "/show/all": {
+    "/shows/all": {
       "get": {
         "tags": [
           "Show Request"
@@ -107,7 +107,7 @@
             "content": {
               "text/html": {
                 "schema": {
-                  "$ref": "component.json#/components/schemas/ShowRequests"
+                  "$ref": "component.json#/components/schemas/ShowBasicRequests"
                 }
               }
             }

--- a/arcsi/static/doc.json
+++ b/arcsi/static/doc.json
@@ -228,7 +228,7 @@
         }
       }
     },
-    "/show/{show_slug}/page": {
+    "/show/{show_slug}/subpages": {
       "get": {
         "tags": [
           "Show Request"


### PR DESCRIPTION
In case that we accidentally send a file to the archives that has been already submitted we now change the filename so it can duplicate safely. 

I renamed one utility function `process` to `save_file` as that is way more exact.

The question is what to do on retrieval & display? 
In use-case one, the show host has a late edit (`mixdown-fin-2` etc.) he wants to upload. In that case the file exists so we change file name of the edited episode and upload it. In this case we would need to fetch this new copy

In another case, someone makes a mistake during the upload process and due to that we accidentally tried uploading something so again the name is safely changed but here we want the opposite to happen: retrieve & display the actual episode.

I'm curious what you think or can think of? I'll try to rest and think this through