### PR TITLE
Quick fix for the legacy API calls

### DIFF
--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -18,6 +18,7 @@ from .utils import (
     dict_to_obj,
     media_path,
     save_file,
+    item_duplications_number
 )
 from arcsi.api import arcsi
 from arcsi.handler.upload import DoArchive
@@ -175,8 +176,7 @@ def add_item():
         )
 
         #Check for duplicate files
-        name_occurrence = int(db.session.query(db.func.count()).filter(Item.name == new_item.name, Item.number == new_item.number).scalar())
-        app.logger.debug("Name_occurence (duplicate detection): {}".format(name_occurrence))
+        name_occurrence = item_duplications_number(new_item)
 
         db.session.add(new_item)
         db.session.flush()
@@ -347,8 +347,7 @@ def edit_item(id):
         item_metadata = item_schema.load(item_metadata)
 
         #Check for duplicate files (before item is updated!)
-        name_occurrence = int(db.session.query(db.func.count()).filter(Item.name == item_metadata.name, Item.number == item_metadata.number).scalar())
-        app.logger.debug("Name_occurence (duplicate detection): {}".format(name_occurrence))
+        name_occurrence = item_duplications_number(item_metadata)
 
         item.number = item_metadata.number
         item.name = item_metadata.name

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -47,6 +47,7 @@ class ShowDetailsSchema(Schema):
                 "play_file_name",
                 "play_date",
                 "image_url",
+                "archived",
                 "download_count"
             ),
         ),

--- a/arcsi/api/utils.py
+++ b/arcsi/api/utils.py
@@ -3,6 +3,7 @@ import os
 from arcsi.handler.upload import AzuraArchive, DoArchive
 from arcsi.model import db
 from arcsi.model.show import Show
+from arcsi.model.item import Item
 from flask import current_app as app
 from slugify import slugify
 from werkzeug import secure_filename
@@ -151,3 +152,8 @@ def get_shows():
                 show.archive_lahmastore_base_url, show.cover_image_url
             )
     return shows
+
+def item_duplications_number(item):
+    name_occurrence = int(db.session.query(db.func.count()).filter(Item.name == item.name, Item.number == item.number).scalar())
+    app.logger.error("Name_occurence (duplicate detection): {}".format(name_occurrence))
+    return name_occurrence


### PR DESCRIPTION
- In a previous merged commit I accidently removed the archived boolean from ShowDetailsSchema's items field. Sorry for that, I believed that we are getting the items of the given show from the /show/{slug}/archive endpoint
- Moved name duplications checker into utils