### PR TITLE
Dev/add error log for playlist assign

### DIFF
--- a/arcsi/handler/upload.py
+++ b/arcsi/handler/upload.py
@@ -251,8 +251,8 @@ class AzuraArchive(object):
             for playlist in r.json():
                 if playlist["name"] == self.playlist_name:
                     self.playlist_id = str(playlist["id"])
-                    return True
                     app.logger.debug("Add to playlist request returned {}".format(r.status_code))
+                    return True                
             app.logger.debug("ERROR: Couldn't find playlist ID in Azuracast response.")
             return False
         app.logger.debug("ERROR: Azuracast request for playlist ID didn't succeed.")

--- a/arcsi/handler/upload.py
+++ b/arcsi/handler/upload.py
@@ -252,7 +252,10 @@ class AzuraArchive(object):
                 if playlist["name"] == self.playlist_name:
                     self.playlist_id = str(playlist["id"])
                     return True
+                    app.logger.debug("Add to playlist request returned {}".format(r.status_code))
+            app.logger.debug("ERROR: Couldn't find playlist ID in Azuracast response.")
             return False
+        app.logger.debug("ERROR: Azuracast request for playlist ID didn't succeed.")
         return False
 
     def empty_playlist(self):


### PR DESCRIPTION
Fixed one failed logging behind a return and added more logging for playlist detection. Tested locally and on dev. Used to debug failing Azuracast upload for one show. Please review. 