### PR TITLE
Extend filter on search endpoint

### DIFF
--- a/arcsi/api/data.py
+++ b/arcsi/api/data.py
@@ -10,7 +10,7 @@ headers = {"Content-Type": "application/json"}
 
 
 @arcsi.route("/data/uploaded_episodes", methods=["POST"])
-@roles_required("guest")
+@roles_required("admin")
 def uploaded_episodes():
     date_metadata = request.form.to_dict()
     end_date = date_metadata["end_date"]

--- a/arcsi/api/utils.py
+++ b/arcsi/api/utils.py
@@ -407,10 +407,14 @@ def get_item_fields_json(item_json, show_json):
 
 
 def search_items(param):
-    return Item.query.filter(
-        func.lower(Item.name).contains(func.lower(param))
-        | func.lower(Item.description).contains(func.lower(param))
-    ).filter(Item.play_date < datetime.today() - timedelta(days=1))
+    return (
+        Item.query.filter(
+            func.lower(Item.name).contains(func.lower(param))
+            | func.lower(Item.description).contains(func.lower(param))
+        )
+        .filter(Item.play_date < datetime.today() - timedelta(days=1))
+        .filter(Item.archived == True)
+    )
 
 
 def search_show_items(param):
@@ -418,6 +422,7 @@ def search_show_items(param):
         Item.query.join(Item.shows)
         .filter(func.lower(Show.name).contains(func.lower(param)))
         .filter(Item.play_date < datetime.today() - timedelta(days=1))
+        .filter(Item.archived == True)
     )
 
 
@@ -426,6 +431,7 @@ def search_tag_items(param):
         Item.query.join(Item.tags)
         .filter(func.lower(Tag.clean_name).contains(normalise(param)))
         .filter(Item.play_date < datetime.today() - timedelta(days=1))
+        .filter(Item.archived == True)
     )
 
 

--- a/arcsi/static/docs/swagger.json
+++ b/arcsi/static/docs/swagger.json
@@ -68,6 +68,11 @@
           "Statistics Request"
         ],
         "summary": "Returns the number of uploaded episodes during the given timeframe",
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "consumes": [
           "multipart/form-data"
         ],

--- a/arcsi/view/data.py
+++ b/arcsi/view/data.py
@@ -1,16 +1,16 @@
 from flask import render_template
-from flask_security import login_required
+from flask_security import roles_required
 
 from arcsi.view import router
 
 
 @router.route("/data")
-@login_required
+@roles_required("admin")
 def view_data():
     return render_template("data/view.html")
 
 
 @router.route("/data/uploaded_episodes")
-@login_required
+@roles_required("admin")
 def uploaded_episodes():
     return render_template("data/uploaded_episodes.html")


### PR DESCRIPTION
- Search endpoint's response should contain only archived episodes
- There is a filter on the frontend side which removes the non-archived episodes
- Restrict access to data endpoints