### PR TITLE
Add stages to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,21 @@
-FROM python:3.11.13-slim-bullseye
+FROM python:3.11.13-slim-bullseye AS builder
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
-
-ADD requirements.txt /app/
-WORKDIR /app
 
 RUN apt-get update \
     && apt-get install gcc g++ \
     libblas-dev libffi-dev liblapack-dev libopenblas-dev libpq-dev \
     musl-dev postgresql tmpreaper -y \
-    && apt-get clean \
-    && pip3 install -r requirements.txt
-
+    && apt-get clean
 ADD infra/tmpreaper.conf /etc/tmpreaper.conf
 
-ADD . /app
+FROM builder AS build
+WORKDIR /app
+ADD . .
+RUN pip3 install -r requirements.txt
 
+FROM build AS init
 EXPOSE 5666
-
-RUN ["chmod", "+x", "/app/entrypoint.sh"]
+RUN ["chmod", "+x", "./entrypoint.sh"]
 ENTRYPOINT []


### PR DESCRIPTION
**Why?** 
This was a huge debt, and both locally and on ci a lot of time is wasted. 

This now addresses our basic separation between infra environment and app environment setup. 

**What changed?**
Consider the previous build failing with `pip` having some dependency problems. It took more than a minute reach that stage.

```
=> [builder 2/3] RUN apt-get update     && apt-get install gcc g++     libblas-dev libffi-dev liblapack-dev libopenblas-dev libpq-dev     libjpeg-dev zlib1g-dev     musl-dev postgresql tmpreaper -y     && apt-get c  72.6s
``` 
With stages segmenting the process, any app dep changes will only take as long as the command is executed. 

```
=> CACHED [builder 2/3] RUN apt-get update     && apt-get install gcc g++     libblas-dev libffi-dev liblapack-dev libopenblas-dev libpq-dev     libjpeg-dev zlib1g-dev     musl-dev postgresql tmpreaper -y     && apt  0.0s
```

and 

```
 => [build 2/3] ADD . .                                                                                                                                                                                                   5.6s
 => [build 3/3] RUN pip3 install -r requirements.txt                                                                                                                                                                     37.2s
```

I also simplified the steps a bit around the `/app` workdir handling.